### PR TITLE
Add support for PATCH method

### DIFF
--- a/src/Backlog.php
+++ b/src/Backlog.php
@@ -43,6 +43,11 @@ class Backlog
 		return $this->request('POST', $data, $params, $option);
 	}
 
+	function patch(array $data = array(), array $params = array(), array $option = array())
+	{
+		return $this->request('PATCH', $data, $params, $option);
+	}
+
 	function delete(array $data = array(), array $params = array(), array $option = array())
 	{
 		return $this->request('DELETE', $data, $params, $option);
@@ -76,6 +81,7 @@ class Backlog
 		$http_method = strtoupper($http_method);
 		switch ($http_method){
 			case 'POST':
+			case 'PATCH':
 				$header  = array_merge(array(
 					'Content-Type' => 'application/x-www-form-urlencoded', // multipart/form-data,
 				), $opt['header']);


### PR DESCRIPTION
Some APIs need PATCH method.
Ex)
- user's info update (/api/v2/users/:userId)
- issue's info update (/api/v2/issues/:issueIdOrKey)
- other 13 APIs

Those headers are only "Content-Type: application / x-www-form-urlencoded".
I did not check all APIs, though I would think my commit is enough.

If there are some mistakes in English, I 'd like to apologize.